### PR TITLE
small improvements to improve compatibility with other SPI devices

### DIFF
--- a/src/ADIS16470.h
+++ b/src/ADIS16470.h
@@ -31,6 +31,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#pragma once
+
 #define ADIS16470_h
 #include "Arduino.h"
 #include <SPI.h>
@@ -109,8 +111,11 @@ public:
   // Performs hardware reset by sending pin 8 low on the DUT for n milliseconds
   int resetDUT(uint8_t ms);
 
-  // Sets SPI bit order, clock divider, and data mode
-  int configSPI();
+  // Sets SPI bit order, clock divider, and data mode and sets CS chip to LOW.
+  int select();
+
+  // Disables SPI bus and sets CS chip to HIGH.
+  int deselect();
 
   // Read single register from sensor
   int16_t regRead(uint8_t regAddr);


### PR DESCRIPTION
* SPI.beginTransaction() is called every time the device is read to/from. This allows multiple SPI devices operating with different modes to work properly together without error if this is forgotten in other libraries.
* Similarly, SPI.endTransaction() is called every time the device has finished reading/writing data
* SPI.end() is no longer called with the destructor so terminating the ADIS16470 object no longer deactivates SPI bus for other devices
* #pragma once is called if this library needs to be called from multiple places